### PR TITLE
fix: strip ?beta query param to fix 404, limit message splitting to DeepSeek

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -230,6 +230,24 @@ function createSSELogger() {
 //  HTTP Proxy
 // ═══════════════════════════════════════════════════════════════
 
+/** Split user messages that mix tool_result blocks with text blocks.
+ *  When OpenRouter translates these to OpenAI format for providers like
+ *  DeepSeek, the tool response must land before the next user message or
+ *  the provider rejects the request ("insufficient tool messages following
+ *  tool_calls message"). */
+function splitMixedMessages(messages) {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+    const toolBlocks = msg.content.filter(b => b.type === "tool_result");
+    const otherBlocks = msg.content.filter(b => b.type !== "tool_result");
+    if (toolBlocks.length > 0 && otherBlocks.length > 0) {
+      msg.content = toolBlocks;
+      messages.splice(i + 1, 0, { role: "user", content: otherBlocks });
+    }
+  }
+}
+
 function proxyRequest(clientReq, clientRes) {
   const { protocol: tgtProto, hostname, port } = CONFIG.target;
   const targetUrl = new URL(clientReq.url, `${tgtProto}//${hostname}`);
@@ -305,7 +323,24 @@ function proxyRequest(clientReq, clientRes) {
     });
   });
 
-  clientReq.pipe(proxyReq);
+  // Buffer the request body so we can split mixed-content user messages
+  // before forwarding (see splitMixedMessages comment above).
+  const chunks = [];
+  clientReq.on("data", (chunk) => chunks.push(chunk));
+  clientReq.on("end", () => {
+    const raw = Buffer.concat(chunks).toString();
+    let body = raw;
+    try {
+      const obj = JSON.parse(raw);
+      if (obj.messages) {
+        splitMixedMessages(obj.messages);
+        body = JSON.stringify(obj);
+      }
+    } catch { /* pass non-JSON bodies through unmodified */ }
+    proxyReq.setHeader("Content-Length", Buffer.byteLength(body));
+    proxyReq.write(body);
+    proxyReq.end();
+  });
 
   clientReq.on("error", (err) => {
     log("error", `Client request error: ${err.message}`);

--- a/proxy.js
+++ b/proxy.js
@@ -253,6 +253,10 @@ function proxyRequest(clientReq, clientRes) {
   const targetUrl = new URL(clientReq.url, `${tgtProto}//${hostname}`);
   if (port) targetUrl.port = port;
 
+  // Strip Anthropic-specific ?beta= query params; OpenRouter uses the
+  // "anthropic-beta" header instead and returns 404 for unknown params.
+  targetUrl.searchParams.delete("beta");
+
   // Rewrite /v1/* → /api/v1/* so clients that omit the /api prefix (e.g. VS
   // Code Claude Code extension) are forwarded to the correct OpenRouter endpoint.
   if (targetUrl.pathname.startsWith("/v1/") || targetUrl.pathname === "/v1") {
@@ -332,7 +336,9 @@ function proxyRequest(clientReq, clientRes) {
     let body = raw;
     try {
       const obj = JSON.parse(raw);
-      if (obj.messages) {
+      // Only split for DeepSeek models (OpenRouter translates to OpenAI
+      // format where tool results must precede the next user message).
+      if (obj.messages && /deepseek/i.test(obj.model)) {
         splitMixedMessages(obj.messages);
         body = JSON.stringify(obj);
       }


### PR DESCRIPTION
## Summary
- Strips Anthropic-specific `?beta=` query parameters before forwarding to OpenRouter (OpenRouter uses the `anthropic-beta` header instead and returns 404 for unknown query params)
- Restricts `splitMixedMessages` to DeepSeek models only, since it creates consecutive `user` messages that violate the Anthropic Messages API contract

## Root cause
The Anthropic SDK (used by VS Code Claude Code extension) appends `?beta=true` to requests. This was being passed through to OpenRouter, which doesn't support it and returned 404.

## Test plan
- [ ] Send a request with `?beta=true` via the proxy → should return 200 (not 404)
- [ ] Send a request without `?beta=true` → should continue to work normally
- [ ] Send a request with `?beta=true&model=claude` → beta stripped, request succeeds
- [ ] DeepSeek model with mixed tool_result/text user messages → message is split correctly
- [ ] Non-DeepSeek model with mixed tool_result/text user messages → messages left intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)