### PR TITLE
fix: strip image tool results for models without vision support

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -230,6 +230,24 @@ function createSSELogger() {
 //  HTTP Proxy
 // ═══════════════════════════════════════════════════════════════
 
+/** Split user messages that mix tool_result blocks with text blocks.
+ *  When OpenRouter translates these to OpenAI format for providers like
+ *  DeepSeek, the tool response must land before the next user message or
+ *  the provider rejects the request ("insufficient tool messages following
+ *  tool_calls message"). */
+function splitMixedMessages(messages) {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+    const toolBlocks = msg.content.filter(b => b.type === "tool_result");
+    const otherBlocks = msg.content.filter(b => b.type !== "tool_result");
+    if (toolBlocks.length > 0 && otherBlocks.length > 0) {
+      msg.content = toolBlocks;
+      messages.splice(i + 1, 0, { role: "user", content: otherBlocks });
+    }
+  }
+}
+
 function proxyRequest(clientReq, clientRes) {
   const { protocol: tgtProto, hostname, port } = CONFIG.target;
   const targetUrl = new URL(clientReq.url, `${tgtProto}//${hostname}`);
@@ -305,7 +323,24 @@ function proxyRequest(clientReq, clientRes) {
     });
   });
 
-  clientReq.pipe(proxyReq);
+  // Buffer the request body so we can split mixed-content user messages
+  // before forwarding (see splitMixedMessages comment above).
+  const chunks = [];
+  clientReq.on("data", (chunk) => chunks.push(chunk));
+  clientReq.on("end", () => {
+    const raw = Buffer.concat(chunks).toString();
+    let body = raw;
+    try {
+      const obj = JSON.parse(raw);
+      if (obj.messages) {
+        splitMixedMessages(obj.messages);
+        body = JSON.stringify(obj);
+      }
+    } catch { /* pass non-JSON bodies through unmodified */ }
+    proxyReq.setHeader("Content-Length", Buffer.byteLength(body));
+    proxyReq.write(body);
+    proxyReq.end();
+  });
 
   clientReq.on("error", (err) => {
     log("error", `Client request error: ${err.message}`);

--- a/proxy.js
+++ b/proxy.js
@@ -253,6 +253,10 @@ function proxyRequest(clientReq, clientRes) {
   const targetUrl = new URL(clientReq.url, `${tgtProto}//${hostname}`);
   if (port) targetUrl.port = port;
 
+  // Strip Anthropic-specific ?beta= query params; OpenRouter uses the
+  // "anthropic-beta" header instead and returns 404 for unknown params.
+  targetUrl.searchParams.delete("beta");
+
   // Rewrite /v1/* → /api/v1/* so clients that omit the /api prefix (e.g. VS
   // Code Claude Code extension) are forwarded to the correct OpenRouter endpoint.
   if (targetUrl.pathname.startsWith("/v1/") || targetUrl.pathname === "/v1") {
@@ -332,7 +336,9 @@ function proxyRequest(clientReq, clientRes) {
     let body = raw;
     try {
       const obj = JSON.parse(raw);
-      if (obj.messages) {
+      // Only split for DeepSeek models (OpenRouter translates to OpenAI
+      // format where tool results must precede the next user message).
+      if (obj.messages && /deepseek/i.test(obj.model)) {
         splitMixedMessages(obj.messages);
         body = JSON.stringify(obj);
       }

--- a/proxy.js
+++ b/proxy.js
@@ -254,14 +254,12 @@ function modelSupportsImages(modelId) {
           modelCache.set(modelId, supports);
           resolve(supports);
         } catch {
-          // If we can't determine, assume it doesn't support images to be safe.
-          modelCache.set(modelId, false);
+          // Malformed response — don't cache so we retry next time.
           resolve(false);
         }
       });
     }).on("error", () => {
-      // Network error — assume no image support to be safe.
-      modelCache.set(modelId, false);
+      // Network error — don't cache so we retry next time.
       resolve(false);
     });
   });
@@ -387,24 +385,30 @@ function proxyRequest(clientReq, clientRes) {
   const chunks = [];
   clientReq.on("data", (chunk) => chunks.push(chunk));
   clientReq.on("end", async () => {
-    const raw = Buffer.concat(chunks).toString();
-    let body = raw;
     try {
-      const obj = JSON.parse(raw);
-      if (obj.messages && obj.model) {
-        const supportsImages = await modelSupportsImages(obj.model);
-        if (!supportsImages) {
-          stripImageToolResults(obj.messages);
+      const raw = Buffer.concat(chunks).toString();
+      let body = raw;
+      try {
+        const obj = JSON.parse(raw);
+        if (obj.messages && obj.model) {
+          const supportsImages = await modelSupportsImages(obj.model);
+          if (!supportsImages) {
+            stripImageToolResults(obj.messages);
+          }
+          if (/deepseek/i.test(obj.model)) {
+            splitMixedMessages(obj.messages);
+          }
+          body = JSON.stringify(obj);
         }
-        if (/deepseek/i.test(obj.model)) {
-          splitMixedMessages(obj.messages);
-        }
-        body = JSON.stringify(obj);
-      }
-    } catch { /* pass non-JSON bodies through unmodified */ }
-    proxyReq.setHeader("Content-Length", Buffer.byteLength(body));
-    proxyReq.write(body);
-    proxyReq.end();
+      } catch { /* pass non-JSON bodies through unmodified */ }
+      proxyReq.setHeader("Content-Length", Buffer.byteLength(body));
+      proxyReq.write(body);
+      proxyReq.end();
+    } catch (err) {
+      log("error", `Request processing error: ${err.message}`);
+      if (!clientRes.headersSent) clientRes.writeHead(500, { "Content-Type": "text/plain" });
+      clientRes.end("Internal proxy error");
+    }
   });
 
   clientReq.on("error", (err) => {

--- a/proxy.js
+++ b/proxy.js
@@ -230,6 +230,61 @@ function createSSELogger() {
 //  HTTP Proxy
 // ═══════════════════════════════════════════════════════════════
 
+// ═══════════════════════════════════════════════════════════════
+//  Model Capabilities Cache
+// ═══════════════════════════════════════════════════════════════
+
+const modelCache = new Map();
+
+/** Fetch model capabilities from OpenRouter and return whether it supports
+ *  image input. Results are cached in memory for the proxy lifetime. */
+function modelSupportsImages(modelId) {
+  return new Promise((resolve) => {
+    if (modelCache.has(modelId)) return resolve(modelCache.get(modelId));
+
+    const url = `https://openrouter.ai/api/v1/models/${encodeURIComponent(modelId)}`;
+    https.get(url, { headers: { accept: "application/json" } }, (res) => {
+      let data = "";
+      res.on("data", (chunk) => data += chunk);
+      res.on("end", () => {
+        try {
+          const json = JSON.parse(data);
+          const modalities = json?.data?.architecture?.input_modalities;
+          const supports = Array.isArray(modalities) && modalities.includes("image");
+          modelCache.set(modelId, supports);
+          resolve(supports);
+        } catch {
+          // If we can't determine, assume it doesn't support images to be safe.
+          modelCache.set(modelId, false);
+          resolve(false);
+        }
+      });
+    }).on("error", () => {
+      // Network error — assume no image support to be safe.
+      modelCache.set(modelId, false);
+      resolve(false);
+    });
+  });
+}
+
+/** Replace tool_result blocks that contain images with an error message
+ *  when the model doesn't support image input. */
+function stripImageToolResults(messages) {
+  let changed = false;
+  for (const msg of messages) {
+    if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+    for (const block of msg.content) {
+      if (block.type !== "tool_result" || !Array.isArray(block.content)) continue;
+      if (block.content.some(c => c.type === "image")) {
+        block.content = "This model cannot decode images.";
+        block.is_error = true;
+        changed = true;
+      }
+    }
+  }
+  return changed;
+}
+
 /** Split user messages that mix tool_result blocks with text blocks.
  *  When OpenRouter translates these to OpenAI format for providers like
  *  DeepSeek, the tool response must land before the next user message or
@@ -327,19 +382,23 @@ function proxyRequest(clientReq, clientRes) {
     });
   });
 
-  // Buffer the request body so we can split mixed-content user messages
-  // before forwarding (see splitMixedMessages comment above).
+  // Buffer the request body so we can inspect messages and optionally
+  // strip image tool results for models that don't support them.
   const chunks = [];
   clientReq.on("data", (chunk) => chunks.push(chunk));
-  clientReq.on("end", () => {
+  clientReq.on("end", async () => {
     const raw = Buffer.concat(chunks).toString();
     let body = raw;
     try {
       const obj = JSON.parse(raw);
-      // Only split for DeepSeek models (OpenRouter translates to OpenAI
-      // format where tool results must precede the next user message).
-      if (obj.messages && /deepseek/i.test(obj.model)) {
-        splitMixedMessages(obj.messages);
+      if (obj.messages && obj.model) {
+        const supportsImages = await modelSupportsImages(obj.model);
+        if (!supportsImages) {
+          stripImageToolResults(obj.messages);
+        }
+        if (/deepseek/i.test(obj.model)) {
+          splitMixedMessages(obj.messages);
+        }
         body = JSON.stringify(obj);
       }
     } catch { /* pass non-JSON bodies through unmodified */ }

--- a/proxy.js
+++ b/proxy.js
@@ -243,7 +243,7 @@ function modelSupportsImages(modelId) {
     if (modelCache.has(modelId)) return resolve(modelCache.get(modelId));
 
     const url = `https://openrouter.ai/api/v1/models/${encodeURIComponent(modelId)}`;
-    https.get(url, { headers: { accept: "application/json" } }, (res) => {
+    const req = https.get(url, { headers: { accept: "application/json" } }, (res) => {
       let data = "";
       res.on("data", (chunk) => data += chunk);
       res.on("end", () => {
@@ -258,8 +258,13 @@ function modelSupportsImages(modelId) {
           resolve(false);
         }
       });
-    }).on("error", () => {
+    });
+    req.on("error", () => {
       // Network error — don't cache so we retry next time.
+      resolve(false);
+    });
+    req.setTimeout(5000, () => {
+      req.destroy();
       resolve(false);
     });
   });
@@ -393,7 +398,8 @@ function proxyRequest(clientReq, clientRes) {
         if (obj.messages && obj.model) {
           const supportsImages = await modelSupportsImages(obj.model);
           if (!supportsImages) {
-            stripImageToolResults(obj.messages);
+            const changed = stripImageToolResults(obj.messages);
+            if (changed && CONFIG.verbose) log("warn", `Stripped image tool results — model=${obj.model} lacks vision support`);
           }
           if (/deepseek/i.test(obj.model)) {
             splitMixedMessages(obj.messages);


### PR DESCRIPTION
## Summary

- **Strip image tool results** for non-vision models to prevent downstream errors
- **Strip `?beta=` query param** — fixes 404 errors from unknown params  
- **Scope `splitMixedMessages` to DeepSeek only** — the split was always DeepSeek-gated but the outer guard changed to allow model-aware filtering

## Changes

- `stripImageToolResults()`: replaces tool_result image blocks with clear error message
- `modelSupportsImages()`: fetches model capabilities from OpenRouter API with in-memory cache, 5s timeout, and no cache on error
- Strips Anthropic `?beta=` query params (fixes 404)
- Debug log when image tool results are stripped

## Test plan

- [ ] Non-vision models receive descriptive error instead of image decode failure
- [ ] Vision-capable models are unaffected
- [ ] Transient network errors during model lookup don't cache permanently
- [ ] Hung model lookups timeout after 5s

🤖 Generated with [Claude Code](https://claude.com/claude-code)