### PR TITLE
fix: log 4xx errors with gzip support, disable DeepSeek thinking mode

### DIFF
--- a/proxy.js
+++ b/proxy.js
@@ -230,6 +230,24 @@ function createSSELogger() {
 //  HTTP Proxy
 // ═══════════════════════════════════════════════════════════════
 
+/** Split user messages that mix tool_result blocks with text blocks.
+ *  When OpenRouter translates these to OpenAI format for providers like
+ *  DeepSeek, the tool response must land before the next user message or
+ *  the provider rejects the request ("insufficient tool messages following
+ *  tool_calls message"). */
+function splitMixedMessages(messages) {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const msg = messages[i];
+    if (msg.role !== "user" || !Array.isArray(msg.content)) continue;
+    const toolBlocks = msg.content.filter(b => b.type === "tool_result");
+    const otherBlocks = msg.content.filter(b => b.type !== "tool_result");
+    if (toolBlocks.length > 0 && otherBlocks.length > 0) {
+      msg.content = toolBlocks;
+      messages.splice(i + 1, 0, { role: "user", content: otherBlocks });
+    }
+  }
+}
+
 function proxyRequest(clientReq, clientRes) {
   const { protocol: tgtProto, hostname, port } = CONFIG.target;
   const targetUrl = new URL(clientReq.url, `${tgtProto}//${hostname}`);
@@ -305,7 +323,24 @@ function proxyRequest(clientReq, clientRes) {
     });
   });
 
-  clientReq.pipe(proxyReq);
+  // Buffer the request body so we can split mixed-content user messages
+  // before forwarding (see splitMixedMessages comment above).
+  const chunks = [];
+  clientReq.on("data", (chunk) => chunks.push(chunk));
+  clientReq.on("end", () => {
+    const raw = Buffer.concat(chunks).toString();
+    let body = raw;
+    try {
+      const obj = JSON.parse(raw);
+      if (obj.messages) {
+        splitMixedMessages(obj.messages);
+        body = JSON.stringify(obj);
+      }
+    } catch { /* pass non-JSON bodies through unmodified */ }
+    proxyReq.setHeader("Content-Length", Buffer.byteLength(body));
+    proxyReq.write(body);
+    proxyReq.end();
+  });
 
   clientReq.on("error", (err) => {
     log("error", `Client request error: ${err.message}`);

--- a/proxy.js
+++ b/proxy.js
@@ -253,6 +253,10 @@ function proxyRequest(clientReq, clientRes) {
   const targetUrl = new URL(clientReq.url, `${tgtProto}//${hostname}`);
   if (port) targetUrl.port = port;
 
+  // Strip Anthropic-specific ?beta= query params; OpenRouter uses the
+  // "anthropic-beta" header instead and returns 404 for unknown params.
+  targetUrl.searchParams.delete("beta");
+
   // Rewrite /v1/* → /api/v1/* so clients that omit the /api prefix (e.g. VS
   // Code Claude Code extension) are forwarded to the correct OpenRouter endpoint.
   if (targetUrl.pathname.startsWith("/v1/") || targetUrl.pathname === "/v1") {
@@ -332,7 +336,9 @@ function proxyRequest(clientReq, clientRes) {
     let body = raw;
     try {
       const obj = JSON.parse(raw);
-      if (obj.messages) {
+      // Only split for DeepSeek models (OpenRouter translates to OpenAI
+      // format where tool results must precede the next user message).
+      if (obj.messages && /deepseek/i.test(obj.model)) {
         splitMixedMessages(obj.messages);
         body = JSON.stringify(obj);
       }

--- a/proxy.js
+++ b/proxy.js
@@ -11,6 +11,7 @@ const http = require("http");
 const https = require("https");
 const { Transform } = require("stream");
 const { URL } = require("url");
+const zlib = require("zlib");
 
 // ═══════════════════════════════════════════════════════════════
 //  Configuration
@@ -67,8 +68,45 @@ function log(level, msg, extra) {
 }
 
 // ═══════════════════════════════════════════════════════════════
-//  Header Helpers
+//  Error Response Logging
 // ═══════════════════════════════════════════════════════════════
+
+/** Passthrough stream that collects the body; logs 4xx responses with
+ *  gzip/deflate/brotli decompression. */
+function createErrorLogStream(statusCode, path, headers) {
+  const chunks = [];
+  const contentEncoding = (headers["content-encoding"] || "").toLowerCase();
+
+  function decode(raw) {
+    if (contentEncoding === "gzip" || contentEncoding === "x-gzip") {
+      try { return zlib.gunzipSync(raw); } catch { /* fall through */ }
+    } else if (contentEncoding === "deflate") {
+      try { return zlib.inflateSync(raw); } catch { /* fall through */ }
+    } else if (contentEncoding === "br") {
+      try { return zlib.brotliDecompressSync(raw); } catch { /* fall through */ }
+    }
+    return raw;
+  }
+
+  function flushBody() {
+    if (chunks.length === 0) return;
+    const raw = decode(Buffer.concat(chunks));
+    let body = raw.toString("utf8");
+    if (body.length > 2000) body = body.slice(0, 2000) + "...[truncated]";
+    if (statusCode >= 400 && statusCode < 500) {
+      log("error", `${statusCode} ${CLR.dim}${path}${CLR.reset}\n${CLR.dim}${body}${CLR.reset}`);
+    }
+  }
+
+  return new Transform({
+    transform(chunk, _enc, cb) {
+      if (statusCode >= 400 && statusCode < 500) chunks.push(chunk);
+      this.push(chunk);
+      cb();
+    },
+    flush(cb) { flushBody(); cb(); },
+  });
+}
 
 function buildProxyHeaders(original) {
   const h = { ...original };
@@ -243,7 +281,7 @@ function splitMixedMessages(messages) {
     const otherBlocks = msg.content.filter(b => b.type !== "tool_result");
     if (toolBlocks.length > 0 && otherBlocks.length > 0) {
       msg.content = toolBlocks;
-      messages.splice(i + 1, 0, { role: "user", content: otherBlocks });
+      messages.splice(i + 1, 0, { ...msg, content: otherBlocks });
     }
   }
 }
@@ -311,7 +349,8 @@ function proxyRequest(clientReq, clientRes) {
     } else if (sse) {
       proxyRes.pipe(createSSELogger()).pipe(clientRes);
     } else {
-      proxyRes.pipe(clientRes);
+      const errLog = createErrorLogStream(proxyRes.statusCode, targetUrl.pathname + targetUrl.search, proxyRes.headers);
+      proxyRes.pipe(errLog).pipe(clientRes);
     }
 
     proxyRes.on("end", () => {
@@ -336,8 +375,17 @@ function proxyRequest(clientReq, clientRes) {
     let body = raw;
     try {
       const obj = JSON.parse(raw);
-      // Only split for DeepSeek models (OpenRouter translates to OpenAI
-      // format where tool results must precede the next user message).
+
+      // Disable DeepSeek thinking mode — it returns reasoning_content that
+      // must be echoed back on subsequent requests, which Claude Code doesn't
+      // do, causing 400 errors.
+      if (obj.model && /deepseek/i.test(obj.model)) {
+        if (!obj.thinking || obj.thinking.type !== "disabled") {
+          obj.thinking = { type: "disabled" };
+          body = JSON.stringify(obj);
+        }
+      }
+
       if (obj.messages && /deepseek/i.test(obj.model)) {
         splitMixedMessages(obj.messages);
         body = JSON.stringify(obj);


### PR DESCRIPTION
## Summary

- **Log 4xx error bodies** with automatic gzip/deflate/brotli decompression so upstream error causes are visible in the console
- **Disable DeepSeek thinking mode** by injecting `"thinking": {"type": "disabled"}` — prevents `reasoning_content` from being returned, which Claude Code doesn't echo back, causing 400 errors on multi-turn conversations
- **Preserve all message fields** when splitting mixed-content messages (`{ ...msg, content: otherBlocks }` instead of bare `{ role, content }`)

## Why

DeepSeek's thinking mode returns `reasoning_content` on assistant messages that must be passed back verbatim in the next request. Claude Code strips this field, so the follow-up request gets rejected with:
```
The `reasoning_content` in the thinking mode must be passed back to the API.
```

Disabling thinking mode is the cleanest fix — it prevents the field from ever appearing, rather than trying to fix Claude Code's message handling.

## Test plan

- [ ] Verify DeepSeek multi-turn conversations work without 400 errors
- [ ] Verify 4xx error bodies appear in proxy console output
- [ ] Verify non-DeepSeek models are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)